### PR TITLE
 OpenPoseと3dBaselineの部位の対応関係を修正/入力データのスケールを調整

### DIFF
--- a/src/openpose_3dpose_sandbox_vmd.py
+++ b/src/openpose_3dpose_sandbox_vmd.py
@@ -20,7 +20,7 @@ import openpose_utils
 import sys
 FLAGS = tf.app.flags.FLAGS
 
-order = [15, 12, 25, 26, 27, 17, 18, 19, 1, 2, 3, 6, 7, 8]
+order = [15, 13, 25, 26, 27, 17, 18, 19, 1, 2, 3, 6, 7, 8]
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -126,10 +126,13 @@ def main(_):
             for j in range(2):
                 # Hip
                 enc_in[0][0 * 2 + j] = (enc_in[0][1 * 2 + j] + enc_in[0][6 * 2 + j]) / 2
-                # Neck/Nose
-                enc_in[0][14 * 2 + j] = (enc_in[0][15 * 2 + j] + enc_in[0][12 * 2 + j]) / 2
                 # Thorax
-                enc_in[0][13 * 2 + j] = 2 * enc_in[0][12 * 2 + j] - enc_in[0][14 * 2 + j]
+                # 3dPoseBaselineのThoraxの位置は、OpenPoseのNeckの位置より少し上のため調整する
+                enc_in[0][13 * 2 + j] = 1.1 * enc_in[0][13 * 2 + j] - 0.1 * enc_in[0][0 * 2 + j]
+                # Neck/Nose
+                enc_in[0][14 * 2 + j] = (enc_in[0][15 * 2 + j] + enc_in[0][13 * 2 + j]) / 2
+                # Spine
+                enc_in[0][12 * 2 + j] = (enc_in[0][0 * 2 + j] + enc_in[0][13 * 2 + j]) / 2
 
             # set spine
             spine_x = enc_in[0][24]

--- a/src/openpose_3dpose_sandbox_vmd.py
+++ b/src/openpose_3dpose_sandbox_vmd.py
@@ -305,9 +305,12 @@ def main(_):
             p3d = poses3d
             # logger.debug("poses3d")
             # logger.debug(poses3d)
+            if frame == start_frame_index:
+                first_xyz = [0,0,0]
+                first_xyz[0], first_xyz[1], first_xyz[2]= p3d[0], p3d[1], p3d[2]
 
             if level[FLAGS.verbose] == logging.INFO:
-                viz.show3Dpose(p3d, ax, lcolor="#9b59b6", rcolor="#2ecc71", add_labels=True)
+                viz.show3Dpose(p3d, ax, lcolor="#9b59b6", rcolor="#2ecc71", add_labels=True, root_xyz=first_xyz)
 
                 # 各フレームの単一視点からのはINFO時のみ
                 pngName = frame3d_dir + '/tmp_{0:012d}.png'.format(frame)
@@ -321,7 +324,7 @@ def main(_):
                 for azim in [0, 45, 90, 135, 180, 225, 270, 315, 360]:
                     ax2 = plt.subplot(gs1[subplot_idx - 1], projection='3d')
                     ax2.view_init(18, azim)
-                    viz.show3Dpose(p3d, ax2, lcolor="#FF0000", rcolor="#0000FF", add_labels=True)
+                    viz.show3Dpose(p3d, ax2, lcolor="#FF0000", rcolor="#0000FF", add_labels=True, root_xyz=first_xyz)
 
                     pngName2 = frame3d_dir + '/tmp_{0:012d}_{1:03d}.png'.format(frame, azim)
                     plt.savefig(pngName2)

--- a/src/viz.py
+++ b/src/viz.py
@@ -8,7 +8,7 @@ import h5py
 import os
 from mpl_toolkits.mplot3d import Axes3D
 
-def show3Dpose(channels, ax, lcolor="#3498db", rcolor="#e74c3c", add_labels=False): # blue, orange
+def show3Dpose(channels, ax, lcolor="#3498db", rcolor="#e74c3c", add_labels=False, root_xyz=None): # blue, orange
   """
   Visualize a 3d skeleton
 
@@ -33,11 +33,16 @@ def show3Dpose(channels, ax, lcolor="#3498db", rcolor="#e74c3c", add_labels=Fals
     x, y, z = [np.array( [vals[I[i], j], vals[J[i], j]] ) for j in range(3)]
     ax.plot(x, y, z, marker='o', markersize=2, lw=1, c=lcolor if LR[i] else rcolor)
 
-  RADIUS = 750 # space around the subject
-  xroot, yroot, zroot = vals[0,0], vals[0,1], vals[0,2]
-  ax.set_xlim3d([-RADIUS+xroot, RADIUS+xroot])
-  ax.set_zlim3d([-RADIUS+zroot, RADIUS+zroot])
-  ax.set_ylim3d([-RADIUS+yroot, RADIUS+yroot])
+  if root_xyz is not None:
+    ax.set_xlim3d([-1500+root_xyz[0], 1500+root_xyz[0]])
+    ax.set_zlim3d([-1000+root_xyz[2], 1000+root_xyz[2]])
+    ax.set_ylim3d([-1200+root_xyz[1], 1200+root_xyz[1]])
+  else:
+    RADIUS = 750 # space around the subject
+    xroot, yroot, zroot = vals[0,0], vals[0,1], vals[0,2]
+    ax.set_xlim3d([-RADIUS+xroot, RADIUS+xroot])
+    ax.set_zlim3d([-RADIUS+zroot, RADIUS+zroot])
+    ax.set_ylim3d([-RADIUS+yroot, RADIUS+yroot])
 
   if add_labels:
     ax.set_xlabel("x")


### PR DESCRIPTION
OpenPoseのNeckを、3dPoseBaselineの13.Thoraxに対応させる。修正前は12.Spine
3dPoseBaselineのThoraxの位置は、OpenPoseのNeckの位置より少し上のため、Thoraxを少し上げる
![openpose_3dbaseline](https://user-images.githubusercontent.com/23007499/51795609-d7246180-2229-11e9-9bc1-a6eaea0197c1.png)

入力データのスケールが教師データと大きく異なると精度が落ちるため大きさを調整する