### PR TITLE
短時間の動画の場合にエラーになる不具合を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 data/
 experiments/
+experiments2/
 result/
 -p/
 *~
@@ -12,3 +13,6 @@ result/
 *.zip
 *.html
 
+command.txt
+OpenposeToVmd.bat
+openpose_3dpose_sandbox_vmd2.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 data/
 experiments/
-experiments2/
 result/
 -p/
 *~
@@ -13,6 +12,3 @@ result/
 *.zip
 *.html
 
-command.txt
-OpenposeToVmd.bat
-openpose_3dpose_sandbox_vmd2.py

--- a/OpenposeTo3D.bat
+++ b/OpenposeTo3D.bat
@@ -38,6 +38,6 @@ IF /I "%IS_DEBUG%" EQU "warn" (
 )
 
 rem ---  python é¿çs
-python src/openpose_3dpose_sandbox_vmd.py --camera_frame --residual --batch_norm --dropout 0.5 --max_norm --evaluateActionWise --use_sh --epochs 200 --load 4874200 --gif_fps 30 --verbose %VERBOSE% --openpose %TARGET_DIR% --person_idx 1
+python src/openpose_3dpose_sandbox_vmd.py --camera_frame --residual --batch_norm --dropout 0.5 --max_norm --evaluateActionWise --epochs 200 --load 4874200 --gif_fps 30 --verbose %VERBOSE% --openpose %TARGET_DIR% --person_idx 1
 
 

--- a/OpenposeTo3D.bat
+++ b/OpenposeTo3D.bat
@@ -38,6 +38,6 @@ IF /I "%IS_DEBUG%" EQU "warn" (
 )
 
 rem ---  python é¿çs
-python src/openpose_3dpose_sandbox_vmd.py --camera_frame --residual --batch_norm --dropout 0.5 --max_norm --evaluateActionWise --epochs 200 --load 4874200 --gif_fps 30 --verbose %VERBOSE% --openpose %TARGET_DIR% --person_idx 1
+python src/openpose_3dpose_sandbox_vmd.py --camera_frame --residual --batch_norm --dropout 0.5 --max_norm --evaluateActionWise --use_sh --epochs 200 --load 4874200 --gif_fps 30 --verbose %VERBOSE% --openpose %TARGET_DIR% --person_idx 1
 
 

--- a/src/openpose_3dpose_sandbox_vmd.py
+++ b/src/openpose_3dpose_sandbox_vmd.py
@@ -151,8 +151,17 @@ def main(_):
                 enc_in[0][13 * 2 + j] = 1.1 * enc_in[0][13 * 2 + j] - 0.1 * enc_in[0][0 * 2 + j]
                 # Neck/Nose
                 enc_in[0][14 * 2 + j] = (enc_in[0][15 * 2 + j] + enc_in[0][13 * 2 + j]) / 2
-                # Spine
-                enc_in[0][12 * 2 + j] = (enc_in[0][0 * 2 + j] + enc_in[0][13 * 2 + j]) / 2
+                # # Spine
+                # enc_in[0][12 * 2 + j] = (enc_in[0][0 * 2 + j] + enc_in[0][13 * 2 + j]) / 2
+
+            # Spine
+            enc_in[0][12 * 2] = (enc_in[0][13 * 2] + enc_in[0][0 * 2]) / 2
+            enc_in[0][12 * 2 + 1] = 0.8 * enc_in[0][13 * 2 + 1] + 0.1 * enc_in[0][0 * 2 + 1] 
+
+            # # Headの傾きに耳を利用する(joints_arrayにないので、直接参照)
+            # enc_in[0][15 * 2 + 0] += (xy[16*2] - xy[17*2]) / 2
+            # Headを少し上げる
+            enc_in[0][15 * 2 + 1] = 0.9 * enc_in[0][15 * 2 + 1]
 
             # set spine
             # spine_x = enc_in[0][24]
@@ -250,6 +259,13 @@ def main(_):
             poses3d_op_xy[15 * 3] += 0.5 * (poses3d_op_xy[14 * 3] - poses3d_op_xy[13 * 3])
             poses3d_op_xy[15 * 3 + 1] += 0.5 * (poses3d_op_xy[14 * 3 + 1] - poses3d_op_xy[13 * 3 + 1])
             poses3d_op_xy[15 * 3 + 2] += 0.5 * (poses3d_op_xy[14 * 3 + 2] - poses3d_op_xy[13 * 3 + 2])
+            
+            # poses3d_op_xy[15 * 3] -= 1 * abs(poses3d_op_xy[14 * 3] - poses3d_op_xy[13 * 3])
+            # poses3d_op_xy[15 * 3 + 1] += 0.3 * (poses3d_op_xy[14 * 3 + 1] - poses3d_op_xy[13 * 3 + 1])
+            # poses3d_op_xy[15 * 3 + 2] += 0.3 * (poses3d_op_xy[14 * 3 + 2] - poses3d_op_xy[13 * 3 + 2])
+            # # Headを調整してからNeck/Noseを調整する
+            # poses3d_op_xy[14 * 3] -= 1 * abs(poses3d_op_xy[14 * 3] - poses3d_op_xy[13 * 3])
+            # poses3d_op_xy[14 * 3 + 1] -= 0.5 * (poses3d_op_xy[14 * 3 + 1] - poses3d_op_xy[13 * 3 + 1])
 
             poses3d_list[frame] = poses3d_op_xy
 

--- a/src/openpose_3dpose_sandbox_vmd.py
+++ b/src/openpose_3dpose_sandbox_vmd.py
@@ -151,17 +151,8 @@ def main(_):
                 enc_in[0][13 * 2 + j] = 1.1 * enc_in[0][13 * 2 + j] - 0.1 * enc_in[0][0 * 2 + j]
                 # Neck/Nose
                 enc_in[0][14 * 2 + j] = (enc_in[0][15 * 2 + j] + enc_in[0][13 * 2 + j]) / 2
-                # # Spine
-                # enc_in[0][12 * 2 + j] = (enc_in[0][0 * 2 + j] + enc_in[0][13 * 2 + j]) / 2
-
-            # Spine
-            enc_in[0][12 * 2] = (enc_in[0][13 * 2] + enc_in[0][0 * 2]) / 2
-            enc_in[0][12 * 2 + 1] = 0.8 * enc_in[0][13 * 2 + 1] + 0.1 * enc_in[0][0 * 2 + 1] 
-
-            # # Headの傾きに耳を利用する(joints_arrayにないので、直接参照)
-            # enc_in[0][15 * 2 + 0] += (xy[16*2] - xy[17*2]) / 2
-            # Headを少し上げる
-            enc_in[0][15 * 2 + 1] = 0.9 * enc_in[0][15 * 2 + 1]
+                # Spine
+                enc_in[0][12 * 2 + j] = (enc_in[0][0 * 2 + j] + enc_in[0][13 * 2 + j]) / 2
 
             # set spine
             # spine_x = enc_in[0][24]
@@ -259,13 +250,6 @@ def main(_):
             poses3d_op_xy[15 * 3] += 0.5 * (poses3d_op_xy[14 * 3] - poses3d_op_xy[13 * 3])
             poses3d_op_xy[15 * 3 + 1] += 0.5 * (poses3d_op_xy[14 * 3 + 1] - poses3d_op_xy[13 * 3 + 1])
             poses3d_op_xy[15 * 3 + 2] += 0.5 * (poses3d_op_xy[14 * 3 + 2] - poses3d_op_xy[13 * 3 + 2])
-            
-            # poses3d_op_xy[15 * 3] -= 1 * abs(poses3d_op_xy[14 * 3] - poses3d_op_xy[13 * 3])
-            # poses3d_op_xy[15 * 3 + 1] += 0.3 * (poses3d_op_xy[14 * 3 + 1] - poses3d_op_xy[13 * 3 + 1])
-            # poses3d_op_xy[15 * 3 + 2] += 0.3 * (poses3d_op_xy[14 * 3 + 2] - poses3d_op_xy[13 * 3 + 2])
-            # # Headを調整してからNeck/Noseを調整する
-            # poses3d_op_xy[14 * 3] -= 1 * abs(poses3d_op_xy[14 * 3] - poses3d_op_xy[13 * 3])
-            # poses3d_op_xy[14 * 3 + 1] -= 0.5 * (poses3d_op_xy[14 * 3 + 1] - poses3d_op_xy[13 * 3 + 1])
 
             poses3d_list[frame] = poses3d_op_xy
 

--- a/src/openpose_3dpose_sandbox_vmd.py
+++ b/src/openpose_3dpose_sandbox_vmd.py
@@ -373,7 +373,7 @@ def calc_move_average(data, n):
         move_avg = np.convolve(data, np.ones(n)/n, 'valid')
         result = np.hstack((np.tile([move_avg[0]], fore_n), move_avg, np.tile([move_avg[-1]], back_n)))
     else:
-        ave = mean(data)
+        ave = np.mean(data)
         result = np.tile([ave], len(data))
 
     return result


### PR DESCRIPTION
ver1.00へのバージョンアップ時の不具合で、90frame以下の短時間の動画で"NameError: name 'mean' is not defined'が発生するようになったため修正