### PR TITLE
動画冒頭に人数分揃ってないとエラーになる問題を回避

### DIFF
--- a/src/openpose_3dpose_sandbox_vmd.py
+++ b/src/openpose_3dpose_sandbox_vmd.py
@@ -310,7 +310,7 @@ def main(_):
             p3d = poses3d
             # logger.debug("poses3d")
             # logger.debug(poses3d)
-            if frame == start_frame_index:
+            if frame == 0:
                 first_xyz = [0,0,0]
                 first_xyz[0], first_xyz[1], first_xyz[2]= p3d[0], p3d[1], p3d[2]
 


### PR DESCRIPTION
・　動画冒頭に人数分揃ってないとエラーになる問題を回避
・　【深度推定】を、深度推定処理と人物INDEX並び替え処理に分割
・　首・頭・上半身2の角度調整
・　vmd出力ファイルの命名規則を変更
・　しゃがんで停止するモーションで、たまに人物が滑ってしまう問題を解決 (kenkra様）
